### PR TITLE
Documentation Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ This Ansible Network role provides a set of platform dependent configuration man
 
 ## [](https://github.com/aruba/aruba-central-ansible-role#requirements)Requirements
 
--   Python 2.7 or 3.5+
--   Ansible 2.9.0 or later
--   Minimum supported Aruba Central firmware version 2.5.2
-
+- Python 2.7 or 3.5+
+- Ansible 2.9.0 or later
+- Minimum supported Aruba Central firmware version 2.5.2
 
 ## [](https://github.com/aruba/aruba-central-ansible-role#notes)Notes
--   The Aruba Central Ansible modules use Central's REST API. For information on REST API and instructions for obtaining an access to the REST API, see the Developer Hub pages in the Aruba Central REST API section, beginning with [Getting Started with REST API](https://developer.arubanetworks.com/aruba-central/docs/getting-started)
--   An API token must be created for a user on Aruba Central and a valid, non-expired **access_token** must be present
--   Ensure that the access token was created with "Network Operations" selected in the Application drop-down list. 
--   An access token is valid for a period of 7200 seconds or two hours. After two hours, it will expire and a new token needs to be created. The token expiry time is currently not configurable.
+
+- The Aruba Central Ansible modules use Central's REST API. For information on REST API and instructions for obtaining an access to the REST API, see the Developer Hub pages in the Aruba Central REST API section, beginning with [Getting Started with REST API](https://developer.arubanetworks.com/aruba-central/docs/getting-started)
+- An API token must be created for a user on Aruba Central and a valid, non-expired **access_token** must be present
+- Ensure that the access token was created with "Network Operations" selected in the Application drop-down list. 
+- An access token is valid for a period of 7200 seconds or two hours. After two hours, it will expire and a new token needs to be created. The token expiry time is currently not configurable.
 
 ## [](https://github.com/aruba/aruba-central-ansible-role#installation)Installation
 
@@ -30,6 +30,7 @@ ansible-galaxy install arubanetworks.aruba_central_role
 ```
 
 Additionally, you'll need to install the `requests` library. You can do so with the following command: 
+
 ```
 pip install -r requirements.txt
 ```
@@ -38,15 +39,16 @@ pip install -r requirements.txt
 
 The variables that should be defined in your inventory for your Aruba Central account are:
 
--   `ansible_host`: Base URL path for API-gateway on Aruba Central in FQDN format
--   `ansible_connection`: Must always be set to  `httpapi`
--   `ansible_network_os`: Must always be set to  `aruba_central`
--   `ansible_httpapi_use_ssl`: Must always be set to  `True`
--   `ansible_httpapi_session_key`: Aruba Central's API access token
+- `ansible_host`: Base URL path for API-gateway on Aruba Central in FQDN format
+- `ansible_connection`: Must always be set to  `httpapi`
+- `ansible_network_os`: Must always be set to  `aruba_central`
+- `ansible_httpapi_use_ssl`: Must always be set to  `True`
+- `ansible_httpapi_session_key`: Aruba Central's API access token
 
 ### [](https://github.com/aruba/aos-wlan-ansible-role#sample-inventories)Sample Inventories:
 
 ##### YAML
+
 ```YAML
 all:
   hosts:
@@ -73,30 +75,30 @@ If role installed through  [Github](https://github.com/aruba/aruba-central-ansib
     ---
     -  hosts: all
        roles:
-        - role: aruba-central-ansible-role
+         - role: aruba-central-ansible-role
        tasks:
-         - name: Get all the UI and Template Groups on Central
-		   central_groups:
-		     action: get
-		     limit: 20
-		     offset: 0
+       - name: Get all the UI and Template Groups on Central
+         central_groups:
+           action: get_groups
+           limit: 20
+           offset: 0
 
 If role installed through  [Galaxy](https://galaxy.ansible.com/arubanetworks/aruba_central_role)  set role to  `arubanetworks.aruba_central_role`:
 
     ---
     -  hosts: all
        roles:
-        - role: arubanetworks.aos_wlan_role
+         - role: arubanetworks.aruba_central_role
        tasks:
-         - name: Get all the UI and Template Groups on Central
-		   central_groups:
-		     action: get
-		     limit: 20
-		     offset: 0
-
+       - name: Get all the UI and Template Groups on Central
+         central_groups:
+           action: get_groups
+           limit: 20
+           offset: 0
 
 Contribution
 -------
+
 At Aruba Networks we're dedicated to ensuring the quality of our products, so if you find any
 issues at all please open an issue on our [Github](https://github.com/aruba/aruba-central-ansible-role) and we'll be sure to respond promptly!
 
@@ -110,5 +112,5 @@ MIT
 Author Information
 ------------------
 
--   Jay Pathak (@jayp193)
--   Derek Wang (@derekwangHPEAruba)
+- Jay Pathak (@jayp193)
+- Derek Wang (@derekwangHPEAruba)


### PR DESCRIPTION
* Replace the action "get" with "get_groups"
* Most of the spacing issues were tabs in place of spaces

Resolves #2 