### PR TITLE
List Addition With .items() (Python2/Python3)

### DIFF
--- a/library/central_sites.py
+++ b/library/central_sites.py
@@ -410,9 +410,9 @@ def api_call(module):
             module.exit_json(changed=False, msg=result['resp'],
                              response_code=result['code'])
         elif site_address is not None:
-            data = dict(site_dict.items() + addr_dict.items())
+            data = dict(list(site_dict.items()) + list(addr_dict.items()))
         elif geolocation is not None:
-            data = dict(site_dict.items() + geo_dict.items())
+            data = dict(list(site_dict.items()) + list(geo_dict.items()))
         if action == "create":
             result = create_site(central_api, data)
         elif action == "update":


### PR DESCRIPTION
* Typecast the returned dict_items from Python3 into list

Local testing with sample dictionaries in Python 2 and Python 3 via Docker shows it resolves the issue. It does cause an aditional list to be created in Python 2 because it returns a list already. The overhead for the limited set of users still on Python 2 this is likely not a concern.

```
$ podman run --rm -it python:2.7
Python 2.7.18 (default, Apr 20 2020, 19:27:10) 
[GCC 8.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> dict(list({"a": "b", "c": "d"}.items()) + list({"a": "b", "c": "d"}.items()))
{'a': 'b', 'c': 'd'}
>>> quit()

$ podman run --rm -it python:3.9
Python 3.9.0 (default, Nov 18 2020, 13:28:38) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> dict(list({"a": "b", "c": "d"}.items()) + list({"a": "b", "c": "d"}.items()))
{'a': 'b', 'c': 'd'}
>>> quit()
```

Resolves #5 